### PR TITLE
Changing Lists help output.

### DIFF
--- a/src/Zbot/Service/Lists.hs
+++ b/src/Zbot/Service/Lists.hs
@@ -55,10 +55,11 @@ listsCommand reply args = listsAction (T.words args)
         -- The usage message, in case no arguments are passed.
         help = mapM_ (lift . reply) [
                   "!list show [list]"
-              ,   "!list add [at index] list [element]"
-              ,   "!list rm list [element]"
-              ,   "!list check list element"
-              ,   "!list flush list"
+              ,   "!list add [list] [element]"
+              ,   "!list add at [index] [list] [element]"
+              ,   "!list rm [list] [element]"
+              ,   "!list check [list] [element]"
+              ,   "!list flush [list]"
               ]
 
         -- Displays the list of lists.


### PR DESCRIPTION
This breaks unix convention, but the lack of unixlike '-' or '--' flags makes following convention unclear.
