### PR TITLE
Add unit test utilities

### DIFF
--- a/src/Zbot/Core/Irc.hs
+++ b/src/Zbot/Core/Irc.hs
@@ -2,6 +2,7 @@
 module Zbot.Core.Irc (
     Irc
 ,   Event (..)
+,   Priority (..)
 
 ,   Server
 ,   Port

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -6,6 +6,7 @@ import Zbot.Tests.Reputation
 
 import Test.Tasty
 
+
 main :: IO ()
 main = defaultMain $ testGroup "ZBot Tests" [
     dudeTests,

--- a/test/Zbot/TestCase.hs
+++ b/test/Zbot/TestCase.hs
@@ -1,7 +1,12 @@
-module Zbot.TestCase where
+{-# LANGUAGE OverloadedStrings #-}
+module Zbot.TestCase (
+  mockBotTestCase
+, replyOutput
+) where
 
-import Zbot.Core.Irc
 import Zbot.Core.Bot.Mock
+import Zbot.Core.Irc
+import Zbot.Core.Irc.Protocol
 
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -9,9 +14,18 @@ import System.IO.Temp
 
 import qualified Data.Text as T
 
-zbotTestCase :: String -> MockBot () -> [Event] -> [T.Text] -> TestTree
-zbotTestCase description botInit events expected = testCase description $ do
+
+-- | Creates a test case that executes a series of events in a mock bot and
+-- asserts that the output matches that given.
+mockBotTestCase :: String -> MockBot () -> [Event] -> [Output] -> TestTree
+mockBotTestCase description botInit events expected = testCase description $
   withSystemTempDirectory "zbot-test" $ \tempDir -> do
     -- Drop the initial handshake since it is common among all tests.
     actual <- drop 3 <$> evalMockBot tempDir botInit events
     actual @?= expected
+
+-- | Creates an Output value that corresponds to Zbot sending a message to a
+-- channel.
+replyOutput :: T.Text -> T.Text -> Output
+replyOutput channel message =
+    Output BestEffort (Message Nothing "PRIVMSG" [channel] (Just message))

--- a/test/Zbot/Tests/Dude.hs
+++ b/test/Zbot/Tests/Dude.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Zbot.Tests.Dude (dudeTests) where
 
+import Zbot.Core.Bot.Mock
 import Zbot.Core.Irc
 import Zbot.Core.Service
 import Zbot.Service.Dude
@@ -8,16 +9,17 @@ import Zbot.TestCase
 
 import Test.Tasty
 
+
 services = registerService_ dude
 
 dudeTests = testGroup "Dude Tests" [
-    zbotTestCase
+    mockBotTestCase
       "Positive Dude Test"
       services
       [Shout "#channel" "nick" "o/"]
-      ["[->IRC] (BestEffort) PRIVMSG #channel :\\o\r\n"]
+      [replyOutput "#channel" "\\o"]
 
-  , zbotTestCase
+  , mockBotTestCase
       "Negative Dude Test"
       services
       [Shout "#channel" "nick" "o"]

--- a/test/Zbot/Tests/Reputation.hs
+++ b/test/Zbot/Tests/Reputation.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Zbot.Tests.Reputation (reputationTests) where
 
+import Zbot.Core.Bot.Mock
 import Zbot.Core.Irc
 import Zbot.Core.Service
 import Zbot.Service.Reputation
@@ -8,48 +9,49 @@ import Zbot.TestCase
 
 import Test.Tasty
 
+
 services = registerService_ reputation
 
 reputationTests = testGroup "Reputations Tests" [
-    zbotTestCase
+    mockBotTestCase
       "Initial State Test"
       services
       [Shout "#channel" "nick" "!rep"]
       []
 
-  , zbotTestCase
+  , mockBotTestCase
       "+1 nick"
       services
       [
         Shout "#channel" "nick" "+1 foo"
       , Shout "#channel" "nick" "!rep"
       ]
-      ["[->IRC] (BestEffort) PRIVMSG #channel :foo has 1 rep\r\n"]
+      [replyOutput "#channel" "foo has 1 rep"]
 
-  , zbotTestCase
+  , mockBotTestCase
       "-1 nick"
       services
       [
         Shout "#channel" "nick" "-1 foo"
       , Shout "#channel" "nick" "!rep"
       ]
-      ["[->IRC] (BestEffort) PRIVMSG #channel :foo has -1 rep\r\n"]
+      [replyOutput "#channel" "foo has -1 rep"]
 
-  , zbotTestCase
+  , mockBotTestCase
       "nick++"
       services
       [
         Shout "#channel" "nick" "foo++"
       , Shout "#channel" "nick" "!rep"
       ]
-      ["[->IRC] (BestEffort) PRIVMSG #channel :foo has 1 rep\r\n"]
+      [replyOutput "#channel" "foo has 1 rep"]
 
-  , zbotTestCase
+  , mockBotTestCase
       "++nick"
       services
       [
         Shout "#channel" "nick" "++foo"
       , Shout "#channel" "nick" "!rep"
       ]
-      ["[->IRC] (BestEffort) PRIVMSG #channel :foo has 1 rep\r\n"]
+      [replyOutput "#channel" "foo has 1 rep"]
   ]

--- a/zbot.cabal
+++ b/zbot.cabal
@@ -70,6 +70,7 @@ library
         ,   Zbot.Core.Bot
         ,   Zbot.Core.Bot.Mock
         ,   Zbot.Core.Irc
+        ,   Zbot.Core.Irc.Protocol
         ,   Zbot.Core.Service
         ,   Zbot.Extras.Color
         ,   Zbot.Extras.Command
@@ -111,7 +112,6 @@ library
             Zbot.Core.Bot.Networked
         ,   Zbot.Core.Bot.Types
         ,   Zbot.Core.Irc.Engine
-        ,   Zbot.Core.Irc.Protocol
         ,   Zbot.Core.Irc.Types
         ,   Zbot.Core.Service.IO
         ,   Zbot.Core.Service.Types


### PR DESCRIPTION
This extends the mock bot functionality with a new function,
evalMockBot, to return the output as a list.

This allows runMockBot interactions that previously only existed in ghci
to be codified as tests.