### PR TITLE
Only scrape text links

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,11 +14,11 @@ jobs:
           keys:
             - stack-all-{{checksum "stack.yaml"}}-{{checksum "zbot.cabal"}}
 
-      - run: wget https://github.com/commercialhaskell/stack/releases/download/v1.7.1/stack-1.7.1-linux-x86_64.tar.gz -O /tmp/stack.tar.gz
+      - run: wget https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -O /tmp/stack.tar.gz
       - run: sudo mkdir /tmp/stack-download
       - run: sudo tar -xzf /tmp/stack.tar.gz -C /tmp/stack-download
-      - run: sudo chmod +x /tmp/stack-download/stack-1.7.1-linux-x86_64/stack
-      - run: sudo mv /tmp/stack-download/stack-1.7.1-linux-x86_64/stack /usr/bin/stack
+      - run: sudo chmod +x /tmp/stack-download/stack-2.1.3-linux-x86_64/stack
+      - run: sudo mv /tmp/stack-download/stack-2.1.3-linux-x86_64/stack /usr/bin/stack
 
       - run: stack setup
       - run: stack test

--- a/src/Zbot/Core/Service/IO.hs
+++ b/src/Zbot/Core/Service/IO.hs
@@ -13,6 +13,7 @@ import Zbot.Core.Irc
 import Zbot.Core.Service.Types
 import Zbot.Metrics
 
+import Control.Monad.Fail (MonadFail)
 import Control.Monad.State
 import Data.Char (isAlphaNum)
 import Data.IORef
@@ -39,7 +40,13 @@ data IOCollectiveMeta m = IOCollectiveMeta {
 
 newtype IOCollective m a = MkIOCollective
                            (StateT (IOCollectiveMeta m) m a)
-    deriving (Monad, Functor, Applicative, Catch.MonadCatch, Catch.MonadThrow)
+    deriving (
+        Monad,
+        Functor,
+        Applicative,
+        Catch.MonadCatch,
+        Catch.MonadThrow,
+        MonadFail)
 
 instance MonadIO io => P.MonadMonitor (IOCollective io) where
     doIO = liftIO
@@ -53,6 +60,7 @@ instance MonadTrans IOCollective where
 instance (Applicative io,
           Functor io,
           Catch.MonadCatch io,
+          MonadFail io,
           MonadIO io) => Collective (IOCollective io) where
 
     data Handle (IOCollective io) a =

--- a/src/Zbot/Core/Service/Types.hs
+++ b/src/Zbot/Core/Service/Types.hs
@@ -14,6 +14,7 @@ module Zbot.Core.Service.Types (
 
 import Zbot.Core.Irc
 
+import Control.Monad.Fail (MonadFail)
 import Control.Monad.State
 
 import qualified Control.Monad.Catch as Catch
@@ -52,6 +53,7 @@ newtype MonadService s m b = MkMonadService (StateT (ServiceMeta s) m b)
               Catch.MonadThrow,
               Functor,
               Monad,
+              MonadFail,
               MonadIO,
               MonadTrans)
 
@@ -67,7 +69,7 @@ serviceName :: (Applicative m, Monad m) => MonadService a m T.Text
 serviceName = MkMonadService $ metaName <$> get
 
 -- | A Collective is a group of managed services that can process IRC events.
-class (Applicative m, Functor m, Monad m) => Collective m where
+class (Applicative m, Functor m, Monad m, MonadFail m) => Collective m where
 
     -- | An opaque handle that can be used to run operations in a state monad
     -- containing the state of the corresponding service. The first parameter is

--- a/src/Zbot/Extras/Scrape.hs
+++ b/src/Zbot/Extras/Scrape.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Zbot.Extras.Scrape (
     scrapeURLAsDesktop
 ,   scrapeURLAsMobile
@@ -5,10 +7,14 @@ module Zbot.Extras.Scrape (
 ,   scrapeURLAsUA
 ) where
 
-import Network.Curl.Opts (CurlOption (..))
+import Data.Default (def)
 import Text.HTML.Scalpel
 
+import qualified Data.ByteString as BS
 import qualified Data.Text as T
+import qualified Network.HTTP.Client as HTTP
+import qualified Network.HTTP.Client.TLS as HTTP
+import qualified Network.HTTP.Types.Header as HTTP
 
 
 scrapeURLAsSearchEngine :: T.Text -> Scraper T.Text a -> IO (Maybe a)
@@ -20,11 +26,35 @@ scrapeURLAsMobile = scrapeURLAsUA "NOKIA"
 scrapeURLAsDesktop :: T.Text -> Scraper T.Text a -> IO (Maybe a)
 scrapeURLAsDesktop = scrapeURLAsUA "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
 
-scrapeURLAsUA :: String -> T.Text -> Scraper T.Text a -> IO (Maybe a)
-scrapeURLAsUA userAgent textUrl = scrapeURLWithOpts options url
-    where
-        url = T.unpack textUrl
-        options = [
-                CurlUserAgent userAgent
-            ,   CurlFollowLocation True
-            ]
+scrapeURLAsUA :: BS.ByteString -> T.Text -> Scraper T.Text a -> IO (Maybe a)
+scrapeURLAsUA userAgent textUrl scraper = do
+  manager <- Just <$> HTTP.newManager managerSettings
+  scrapeURLWithConfig (def { manager }) url scraper
+  where
+    url = T.unpack textUrl
+
+    managerSettings :: HTTP.ManagerSettings
+    managerSettings = HTTP.tlsManagerSettings {
+      HTTP.managerModifyRequest = \req -> do
+        req' <- HTTP.managerModifyRequest HTTP.tlsManagerSettings req
+        return $ req' {
+            HTTP.requestHeaders = (HTTP.hUserAgent, userAgent)
+                                : HTTP.requestHeaders req'
+          },
+
+      HTTP.managerModifyResponse = \res -> do
+        res' <- HTTP.managerModifyResponse HTTP.tlsManagerSettings res
+        let isTextContent = (not . null)
+                          $ filter ("text/" `BS.isInfixOf`)
+                          $ map snd
+                          $ filter isContentType
+                          $ HTTP.responseHeaders res'
+        -- For all non-text requests return an empty body.
+        if isTextContent
+          then return $ res'
+          else return $ res' {
+              HTTP.responseBody = return BS.empty
+            }
+    }
+
+    isContentType = (== HTTP.hContentType) . fst

--- a/src/Zbot/Service/Dude.hs
+++ b/src/Zbot/Service/Dude.hs
@@ -70,7 +70,7 @@ dudeHandler event
             (DudeState _ m) <- get
             put $ DudeState (Just t) m
 
-        expireDudes :: Bot m => MonadService DudeState m ()
+        expireDudes :: (Bot m) => MonadService DudeState m ()
         expireDudes = do
             (DudeState (Just t) m) <- get
             let dudesPartitioned = M.map (partitionDudes $ isExpired t) m

--- a/src/Zbot/Service/NGram/Model.hs
+++ b/src/Zbot/Service/NGram/Model.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -31,10 +32,10 @@ type Gram (n :: Nat) a = Seq.Seq (Token a)
 data Distribution a = Distribution {
         distSize    :: Int64
     ,   distSamples :: Map.Map (Token a) Int64
-    } deriving (Eq, Show, Read)
+    } deriving (Eq, Show, Read, Semigroup)
 
 newtype Model (n :: Nat) a = Model (Map.Map (Gram n a) (Distribution a))
-    deriving (Eq, Read)
+    deriving (Eq, Read, Semigroup)
 
 instance Ord a => Monoid (Distribution a) where
     mempty = Distribution 0 Map.empty

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,4 +6,5 @@ extra-deps:
 - prometheus-client-1.0.0
 - prometheus-metrics-ghc-1.0.0
 - wai-middleware-prometheus-1.0.0
-resolver: lts-10.4
+- HTTP-4000.3.14
+resolver: lts-14.9

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -5,6 +5,7 @@ import Zbot.Tests.Dude
 import Zbot.Tests.Replace
 import Zbot.Tests.Reputation
 import Zbot.Tests.Roll
+import Zbot.Tests.Typo
 
 import Test.Tasty
 
@@ -15,4 +16,5 @@ main = defaultMain $ testGroup "ZBot Tests" [
   , replaceTests
   , reputationTests
   , rollTests
+  , typoTests
   ]

--- a/test/Zbot/Tests/Replace.hs
+++ b/test/Zbot/Tests/Replace.hs
@@ -15,7 +15,7 @@ import Data.Time
 
 services = fmap replace (history >>= registerService) >>= registerService_
 
-replaceTests = testGroup "History Tests" [
+replaceTests = testGroup "Replace Tests" [
     mockBotTestCase
       "- simple replace"
       services

--- a/zbot.cabal
+++ b/zbot.cabal
@@ -18,7 +18,6 @@ executable zbot
     main-is:            zbot/Main.hs
     ghc-options:
       -W
-      -Odph
       -optc-O3
       -rtsopts
     default-language:   Haskell2010
@@ -30,7 +29,6 @@ executable zbot
 library
     ghc-options:
       -W
-      -Odph
       -optc-O3
     default-language:   Haskell2010
     hs-source-dirs:     src/
@@ -48,12 +46,15 @@ library
         ,   connection
         ,   containers
         ,   cryptohash
-        ,   curl
         ,   data-default
         ,   directory
+        ,   edit-distance
         ,   exceptions
         ,   filepath
         ,   gitrev
+        ,   http-client
+        ,   http-client-tls
+        ,   http-types
         ,   lens
         ,   lens-aeson
         ,   mmap
@@ -119,6 +120,7 @@ library
         ,   Zbot.Service.Scrollback
         ,   Zbot.Service.Seen
         ,   Zbot.Service.Summary
+        ,   Zbot.Service.Typo
         ,   Zbot.Service.Uptime
         ,   Zbot.Service.Version
 
@@ -154,3 +156,4 @@ test-suite zbot-tests
         ,   Zbot.Tests.Replace
         ,   Zbot.Tests.Reputation
         ,   Zbot.Tests.Roll
+        ,   Zbot.Tests.Typo

--- a/zbot/Main.hs
+++ b/zbot/Main.hs
@@ -28,6 +28,7 @@ import Zbot.Service.Roll
 import Zbot.Service.Scrollback
 import Zbot.Service.Seen
 import Zbot.Service.Summary
+import Zbot.Service.Typo
 import Zbot.Service.Uptime
 import Zbot.Service.Version
 
@@ -60,5 +61,6 @@ main = zbotMain $ do
     registerService_ $ scrollback historyHandle
     registerService_ $ seen historyHandle
     registerService_ $ summary historyHandle
+    registerService_ $ typo 5 historyHandle
     uptime historyHandle >>= registerService_
     registerService_ version


### PR DESCRIPTION
This change updates the web scraping utilities to silently truncate any
non-text mime type response. This should hopefully prevent resource
exhaustion when zbot encounters large images or media files...

In order to do this, scalpel was updated to 0.6, which meant bumping the
resolver to the latest LTS. This caused a GHC version bump which needed
some massaging to take care of.