### PR TITLE
Fix YouTube parsing

### DIFF
--- a/test/Main.hs
+++ b/test/Main.hs
@@ -6,6 +6,7 @@ import Zbot.Tests.Replace
 import Zbot.Tests.Reputation
 import Zbot.Tests.Roll
 import Zbot.Tests.Typo
+import Zbot.Tests.YouTube
 
 import Test.Tasty
 
@@ -17,4 +18,5 @@ main = defaultMain $ testGroup "ZBot Tests" [
   , reputationTests
   , rollTests
   , typoTests
+  , youTubeTests
   ]

--- a/test/Zbot/TestCase.hs
+++ b/test/Zbot/TestCase.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Zbot.TestCase (
   mockBotTestCase
+, mockBotTestCaseWithAssert
+, outputMessage
 , replyOutput
 ) where
 
@@ -18,14 +20,24 @@ import qualified Data.Text as T
 -- | Creates a test case that executes a series of events in a mock bot and
 -- asserts that the output matches that given.
 mockBotTestCase :: String -> MockBot () -> [Event] -> [Output] -> TestTree
-mockBotTestCase description botInit events expected = testCase description $
+mockBotTestCase description botInit events expected =
+    mockBotTestCaseWithAssert description botInit events (@?= expected)
+
+-- | Creates a test case that executes a series of events in a mock bot and
+-- performs a custom assertion on the output.
+mockBotTestCaseWithAssert :: String -> MockBot () -> [Event] -> ([Output] -> Assertion) -> TestTree
+mockBotTestCaseWithAssert description botInit events assertion = testCase description $
   withSystemTempDirectory "zbot-test" $ \tempDir -> do
     -- Drop the initial handshake since it is common among all tests.
     actual <- drop 3 <$> evalMockBot tempDir botInit events
-    actual @?= expected
+    assertion actual
 
 -- | Creates an Output value that corresponds to Zbot sending a message to a
 -- channel.
 replyOutput :: T.Text -> T.Text -> Output
 replyOutput channel message =
     Output BestEffort (Message Nothing "PRIVMSG" [channel] (Just message))
+
+-- | Returns the message component of an Output value.
+outputMessage :: Output -> T.Text
+outputMessage (Output _ (Message Nothing "PRIVMSG" [_] (Just msg))) = msg

--- a/test/Zbot/Tests/YouTube.hs
+++ b/test/Zbot/Tests/YouTube.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Zbot.Tests.YouTube (youTubeTests) where
+
+import Zbot.Core.Bot.Mock
+import Zbot.Core.Irc
+import Zbot.Core.Service
+import Zbot.Service.Describe
+import Zbot.Service.Describe.YouTube
+import Zbot.TestCase
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import qualified Data.Text as T
+import qualified Text.Regex.TDFA
+import qualified Text.Regex.Base.RegexLike as RE
+
+
+services = registerService_ (describe [describeYouTube])
+
+youTubeTests = testGroup "YouTube Tests" [
+    youTubeTestCase
+        "https://www.youtube.com/watch?v=xCD3hg6OEQw"
+        "Slavoj Zizek on KUNG FU PANDA \\[length: 00:02:30, views: [0-9,]+\\]",
+
+    youTubeTestCase
+        "https://www.youtube.com/watch?v=ImFA7F571TA"
+        "Everybody's Gone .* Soundtrack \\[length: 01:05:58, views: [0-9,]+\\]",
+
+    youTubeTestCase
+        "https://youtu.be/I25UeVXrEHQ"
+        "Richard Stallman .* His Foot \\[length: 00:02:22, views: [0-9,]+\\]",
+
+    youTubeTestCase
+        "foo bar https://www.youtube.com/watch?feature=youtu.be&v=XT9IF4CMQDI"
+        "Playing a 7/11 .* 11 seconds \\[length: 00:07:16, views: [0-9,]+\\]"
+ ]
+ where
+    youTubeTestCase url pattern =
+        mockBotTestCaseWithAssert
+          (T.unpack url)
+          services
+          [Shout "#channel" "nick" url]
+          (\actual -> do
+            [message] <- return $ map outputMessage actual
+            RE.matchTest (re pattern) message @?
+                (concat [T.unpack message, " does not match ", pattern]))
+
+re :: String -> Text.Regex.TDFA.Regex
+re = Text.Regex.TDFA.makeRegex

--- a/zbot.cabal
+++ b/zbot.cabal
@@ -143,6 +143,8 @@ test-suite zbot-tests
     build-depends:       base
                        , attoparsec
                        , HUnit
+                       , regex-base
+                       , regex-tdfa
                        , tasty
                        , tasty-hunit
                        , temporary
@@ -157,3 +159,4 @@ test-suite zbot-tests
         ,   Zbot.Tests.Reputation
         ,   Zbot.Tests.Roll
         ,   Zbot.Tests.Typo
+        ,   Zbot.Tests.YouTube


### PR DESCRIPTION
It looks like YouTube updated to a DOM where all the data we need is
included in the watch page. This makes the scraper a lot simpler since
we do not need JSON parsing anymore.

Fixes #159