### PR TITLE
Allow grep to work from private messages

### DIFF
--- a/src/Zbot/Extras/Message.hs
+++ b/src/Zbot/Extras/Message.hs
@@ -3,7 +3,6 @@ module Zbot.Extras.Message (
 ,   MessageContext(..)
 ,   MessageSource(..)
 ,   onMessage
-,   onMessageWithChannel
 )   where
 
 import Zbot.Core.Bot
@@ -36,24 +35,16 @@ data MessageContext m = MessageContext {
 onMessage :: Bot m
           => (MessageContext m -> T.Text -> MonadService s m ())
           -> Event -> MonadService s m ()
-onMessage handler (Shout channel nick msg) = flip handler msg MessageContext {
+onMessage handler (Shout channel nick msg) = handler MessageContext {
     reply           = shout channel
   , shoutBackOrDrop = shout channel
   , whisperBack     = whisper nick
   , source          = ShoutSource channel nick
-  }
-onMessage handler (Whisper nick msg)       = flip handler msg MessageContext {
+  } msg
+onMessage handler (Whisper nick msg)       = handler MessageContext {
     reply           = whisper nick
   , shoutBackOrDrop = \_ -> return ()
   , whisperBack     = whisper nick
   , source          = WhisperSource nick
-  }
+  } msg
 onMessage _       _                        = return ()
-
--- | A utility function for onMessage callers that want access to the their
--- current channel.
-onMessageWithChannel :: Bot m
-                     => (Channel -> MessageContext m -> T.Text -> MonadService s m ())
-                     -> Event -> MonadService s m ()
-onMessageWithChannel handler e@(Shout channel _ _) = onMessage (handler channel) e
-onMessageWithChannel _       _                     = return ()

--- a/src/Zbot/Service/Reputation.hs
+++ b/src/Zbot/Service/Reputation.hs
@@ -29,7 +29,7 @@ reputation = Service {
     ,   serialize   = serializeReputation
     ,   deserialize = deserializeReputation
     ,   name        = "Zbot.Service.Reputation"
-    ,   process     = onMessageWithChannel handler
+    ,   process     = onMessage handler
     ,   helpSpec    = Just HelpSpec {
             helpAliases      = ["!rep", "+1", "-1", "!circlejerk"]
         ,   helpMessage      = [
@@ -67,8 +67,8 @@ deserializeReputation :: BS.ByteString -> Maybe Reputation
 deserializeReputation = fmap MkReputation . deserializeRead
 
 handler :: (MonadIO m, Bot m)
-        => Channel -> MessageContext m -> T.Text -> MonadService Reputation m ()
-handler channel ctx msg
+        => MessageContext m -> T.Text -> MonadService Reputation m ()
+handler ctx@MessageContext{source = ShoutSource channel _} msg
     | ["+1", nick]                      <- args = plus nick
     | ["-1", nick]                      <- args = minus nick
     | [T.stripPrefix "++" -> Just nick] <- args = plus nick
@@ -106,6 +106,7 @@ handler channel ctx msg
         replyRep nick rep = lift
                           $ reply ctx
                           $ T.concat [nick, " has ", showText rep, " rep"]
+handler _ _ = return ()
 
 wrapModify :: Bot m
            => (Map.Map Nick Int -> Map.Map Nick Int)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -2,6 +2,7 @@
 module Main where
 
 import Zbot.Tests.Dude
+import Zbot.Tests.Grep
 import Zbot.Tests.Help
 import Zbot.Tests.Onion
 import Zbot.Tests.Replace
@@ -17,6 +18,7 @@ import Test.Tasty
 main :: IO ()
 main = defaultMain $ testGroup "ZBot Tests" [
     dudeTests
+  , grepTests
   , helpTests
   , onionTests
   , replaceTests

--- a/test/Zbot/Tests/Grep.hs
+++ b/test/Zbot/Tests/Grep.hs
@@ -1,0 +1,146 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Zbot.Tests.Grep (grepTests) where
+
+import Zbot.Core.Bot
+import Zbot.Core.Bot.Mock
+import Zbot.Core.Irc
+import Zbot.Core.Service
+import Zbot.Extras.Color
+import Zbot.Extras.Message
+import Zbot.Extras.UnitService
+import Zbot.Service.Grep
+import Zbot.Service.History
+import Zbot.TestCase
+
+import Control.Monad.Trans.Class (lift)
+import Test.Tasty
+import Data.Time
+
+services = fmap grep (history >>= registerService) >>= registerService_
+
+grepTests = testGroup "Grep Tests" [
+    mockBotTestCase
+      "Match found when requested from channel"
+      services
+      [
+        Shout "#channel" "nick" "foo"
+      , Shout "#channel" "nick" "bar"
+      , Shout "#channel" "nick" "!grep -T o"
+      ]
+      [replyOutput "#channel" $ colorize ["#channel nick> f", fg Red "o", "o"]],
+
+    mockBotTestCase
+      "Match not found when requested from channel"
+      services
+      [
+        Shout "#channel" "nick" "foo"
+      , Shout "#channel" "nick" "bar"
+      , Shout "#channel" "nick" "!grep -T x"
+      ]
+      [replyOutput "#channel" "No matches found."],
+
+    mockBotTestCase
+      "Match found when requested from PM"
+      services
+      [
+        Shout "#channel" "nick" "foo"
+      , Shout "#channel" "nick" "bar"
+      , Whisper "nick" "!grep -C #channel -T o"
+      ]
+      [replyOutput "nick" $ colorize ["#channel nick> f", fg Red "o", "o"]],
+
+    mockBotTestCase
+      "Hide command by default"
+      services
+      [
+        Shout "#channel" "nick" "!foo"
+      , Shout "#channel" "nick" "!grep -T foo"
+      ]
+      [replyOutput "#channel" "No matches found."],
+
+    mockBotTestCase
+      "-S allows commands to be found"
+      services
+      [
+        Shout "#channel" "nick" "!foo"
+      , Shout "#channel" "nick" "!grep -T -S foo"
+      ]
+      [replyOutput "#channel" $ colorize ["#channel nick> !", fg Red "foo"]],
+
+    mockBotTestCase
+      "Returns the most recent match"
+      services
+      [
+        Shout "#channel" "a" "foo"
+      , Shout "#channel" "b" "foo"
+      , Shout "#channel" "nick" "!grep -T foo"
+      ]
+      [replyOutput "#channel" $ colorize ["#channel b> ", fg Red "foo"]],
+
+    mockBotTestCase
+      "-n allows matches to be filtered by nick"
+      services
+      [
+        Shout "#channel" "a" "foo"
+      , Shout "#channel" "b" "foo"
+      , Shout "#channel" "nick" "!grep -T -n a foo"
+      ]
+      [replyOutput "#channel" $ colorize ["#channel a> ", fg Red "foo"]],
+
+    mockBotTestCase
+      "Only search current channel by default"
+      services
+      [
+        Shout "#other" "nick" "foo"
+      , Shout "#channel" "nick" "!grep -T foo"
+      ]
+      [replyOutput "#channel" "No matches found."],
+
+    mockBotTestCase
+      "-C allows other channels to be searched"
+      services
+      [
+        Shout "#other" "nick" "foo"
+      , Shout "#channel" "nick" "!grep -T -C #other foo"
+      ]
+      [replyOutput "#channel" $ colorize ["#other nick> ", fg Red "foo"]],
+
+    mockBotTestCase
+      "-m allows multiple matches to be returned"
+      services
+      [
+        Shout "#channel" "nick" "foo1"
+      , Shout "#channel" "nick" "foo2"
+      , Shout "#channel" "nick" "foo3"
+      , Shout "#channel" "nick" "foo4"
+      , Shout "#channel" "nick" "!grep -T -m 3 foo"
+      ]
+      [
+        replyOutput "#channel" $ colorize ["#channel nick> ", fg Red "foo", "2"]
+      , replyOutput "#channel" $ colorize [fg Cyan "----"]
+      , replyOutput "#channel" $ colorize ["#channel nick> ", fg Red "foo", "3"]
+      , replyOutput "#channel" $ colorize [fg Cyan "----"]
+      , replyOutput "#channel" $ colorize ["#channel nick> ", fg Red "foo", "4"]
+      ],
+
+    mockBotTestCase
+      "-C displays multiple lines of context surrounding the match"
+      services
+      [
+        Shout "#channel" "nick" "1"
+      , Shout "#channel" "nick" "2"
+      , Shout "#channel" "nick" "3"
+      , Shout "#channel" "nick" "foo"
+      , Shout "#channel" "nick" "4"
+      , Shout "#channel" "nick" "5"
+      , Shout "#channel" "nick" "6"
+      , Shout "#channel" "nick" "!grep -T -c 2 foo"
+      ]
+      [
+        replyOutput "#channel" $ colorize ["#channel nick> 2"]
+      , replyOutput "#channel" $ colorize ["#channel nick> 3"]
+      , replyOutput "#channel" $ colorize ["#channel nick> ", fg Red "foo"]
+      , replyOutput "#channel" $ colorize ["#channel nick> 4"]
+      , replyOutput "#channel" $ colorize ["#channel nick> 5"]
+      ]
+  ]

--- a/zbot.cabal
+++ b/zbot.cabal
@@ -156,6 +156,7 @@ test-suite zbot-tests
     other-modules:
             Zbot.TestCase
         ,   Zbot.Tests.Dude
+        ,   Zbot.Tests.Grep
         ,   Zbot.Tests.Help
         ,   Zbot.Tests.Onion
         ,   Zbot.Tests.Replace


### PR DESCRIPTION
This replaces usages of onMessageWithChannel with MessageContext which
provides a mechanism for retrieving the nick and channel for a given
event.

I also added a flag to grep, -T, that suppresses timestamps to make
testing deterministic.

Fixes #93
Fixes #99