### PR TITLE
Do not describe links in commands

### DIFF
--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 
+import Zbot.Tests.Describe
 import Zbot.Tests.Dude
 import Zbot.Tests.Help
 import Zbot.Tests.Onion
@@ -16,7 +17,8 @@ import Test.Tasty
 
 main :: IO ()
 main = defaultMain $ testGroup "ZBot Tests" [
-    dudeTests
+    describeTests
+  , dudeTests
   , helpTests
   , onionTests
   , replaceTests

--- a/test/Zbot/Tests/Describe.hs
+++ b/test/Zbot/Tests/Describe.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Zbot.Tests.Describe (describeTests) where
+
+import Zbot.Core.Bot
+import Zbot.Core.Bot.Mock
+import Zbot.Core.Irc
+import Zbot.Core.Service
+import Zbot.Service.Describe
+import Zbot.TestCase
+
+import Test.Tasty
+import Data.Time
+
+
+echoDescriber :: Describer
+echoDescriber link = Just $ return $ return link
+
+services = registerService_ $ describe [echoDescriber]
+
+describeTests = testGroup "Describe Tests" [
+    mockBotTestCase
+      "A message without a link"
+      services
+      [Shout "#channel" "nick" "message"]
+      [],
+
+    mockBotTestCase
+      "A message that is just an http:// link"
+      services
+      [Shout "#channel" "nick" "http://foobar.com"]
+      [replyOutput "#channel" "http://foobar.com"],
+
+    mockBotTestCase
+      "A message that is just an https:// link"
+      services
+      [Shout "#channel" "nick" "https://foobar.com"]
+      [replyOutput "#channel" "https://foobar.com"],
+
+    mockBotTestCase
+      "A message with a link infix"
+      services
+      [Shout "#channel" "nick" "message with https://foobar.com inside it"]
+      [replyOutput "#channel" "https://foobar.com"],
+
+    mockBotTestCase
+      "A shouted command with a link"
+      services
+      [Shout "#channel" "nick" "!summary https://foobar.com"]
+      [],
+
+    mockBotTestCase
+      "A whispered command with a link"
+      services
+      [Whisper "nick" "!summary https://foobar.com"]
+      []
+  ]

--- a/zbot.cabal
+++ b/zbot.cabal
@@ -155,6 +155,7 @@ test-suite zbot-tests
 
     other-modules:
             Zbot.TestCase
+        ,   Zbot.Tests.Describe
         ,   Zbot.Tests.Dude
         ,   Zbot.Tests.Help
         ,   Zbot.Tests.Onion


### PR DESCRIPTION
This implements the easy solution for #42 by filtering out all messages
that start with a "!" before they are considered by the describe
service.

Fixes #42