### PR TITLE
Ignore messages that end and start with "*" in typo

### DIFF
--- a/src/Zbot/Service/Typo.hs
+++ b/src/Zbot/Service/Typo.hs
@@ -22,6 +22,8 @@ typo :: (MonadIO m, Bot m) => Int -> Handle m History -> Service m ()
 typo maxDistance history = unitService "Zbot.Service.Typo" handler
     where
         handler (Shout channel nick msg)
+            | "*" `T.isPrefixOf` msg && "*" `T.isSuffixOf` msg
+            = return () -- Ignore things like "*vomit*".
             | "*" `T.isSuffixOf` msg
             = lift
             $ handleMessage (shout channel) channel nick msg

--- a/test/Zbot/Tests/Typo.hs
+++ b/test/Zbot/Tests/Typo.hs
@@ -49,4 +49,11 @@ typoTests = testGroup "Typo Tests" [
       [ Shout "#channel" "nick" "tnak"
       , Shout "#channel" "nick" "Rat King*"]
       []
+
+  , mockBotTestCase
+      "- don't correct messages like '*vomit*'"
+      services
+      [ Shout "#channel" "nick" "vmit"
+      , Shout "#channel" "nick" "*vomit*"]
+      []
   ]


### PR DESCRIPTION
Fixes #172